### PR TITLE
Unrescale NK-9V

### DIFF
--- a/GameData/ROEngines/PartConfigs/NK9V_RE.cfg
+++ b/GameData/ROEngines/PartConfigs/NK9V_RE.cfg
@@ -17,4 +17,5 @@
 	@tags = nk9, nk, n1, n-1, gr-1, nk-9, n1f, 9v, nk9v, nk-9v, nk-19, nk-31
 	
 	@engineType = NK9V
+	!MODULE[ModuleB9PartSwitch] {}
 }


### PR DESCRIPTION
Unsure if it would be better to go about this differently (not copying the -43, or setting appropriate subtypes here) but this does fix it being too small.